### PR TITLE
Add new terms

### DIFF
--- a/observation/ECSO8.owl
+++ b/observation/ECSO8.owl
@@ -28571,6 +28571,46 @@ http://en.wikipedia.org/wiki/Soil_organic_matter, 2017-07-08</obo:IAO_0000119>
     
 
 
+    <!-- http://purl.dataone.org/odo/ECSO_00003114 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003114">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001808"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-23T23:17:13Z</dc:date>
+        <oboInOwl:hasExactSynonym>SF6 concentration</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">sulfur hexafluoride concentration</rdfs:label>
+        <skos:altLabel>SF6 concentration</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00003115 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003115">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000669"/>
+        <obo:IAO_0000115>A d13C measurement of carbon dioxide in the atmosphere.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-23T23:22:16Z</dc:date>
+        <oboInOwl:hasExactSynonym>d13C CO2</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">d13C carbon dioxide</rdfs:label>
+        <skos:altLabel>d13C CO2</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00003116 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003116">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00003115"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-23T23:34:47Z</dc:date>
+        <oboInOwl:hasExactSynonym>uncertainty of d13C CO2</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">uncertainty of d13C carbon dioxide</rdfs:label>
+        <skos:altLabel>uncertainty of d13C CO2</skos:altLabel>
+    </owl:Class>
+    
+
+
     <!-- http://purl.dataone.org/odo/ECSO_00003195 -->
 
     <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003195">
@@ -46963,8 +47003,8 @@ New terms or revisions can be requested at https://github.com/EnvironmentOntolog
 
 Please see www.environmentontology.org for more information and citations.</rdfs:comment>
         <dc:creator>http://orcid.org/0000-0002-4366-3088</dc:creator>
-        <dc:creator>http://orcid.org/0000-0003-1604-1512</dc:creator>
         <dc:creator>http://orcid.org/0000-0002-6601-2165</dc:creator>
+        <dc:creator>http://orcid.org/0000-0003-1604-1512</dc:creator>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/envo/modules/entity_quality_location.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 45 Logical Axioms: 6]</rdfs:comment>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/envo/modules/entity_attribute_location.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 138 Logical Axioms: 23]</rdfs:comment>
         <dc:creator>https://orcid.org/0000-0002-6962-2807</dc:creator>

--- a/observation/ECSO8.owl
+++ b/observation/ECSO8.owl
@@ -28560,6 +28560,17 @@ http://en.wikipedia.org/wiki/Soil_organic_matter, 2017-07-08</obo:IAO_0000119>
     
 
 
+    <!-- http://purl.dataone.org/odo/ECSO_00003113 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003113">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000655"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-22T04:36:31Z</dc:date>
+        <rdfs:label xml:lang="en">dissolved organic carbon to dissolved organic nitrogen ratio</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.dataone.org/odo/ECSO_00003195 -->
 
     <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003195">
@@ -46952,8 +46963,8 @@ New terms or revisions can be requested at https://github.com/EnvironmentOntolog
 
 Please see www.environmentontology.org for more information and citations.</rdfs:comment>
         <dc:creator>http://orcid.org/0000-0002-4366-3088</dc:creator>
-        <dc:creator>http://orcid.org/0000-0002-6601-2165</dc:creator>
         <dc:creator>http://orcid.org/0000-0003-1604-1512</dc:creator>
+        <dc:creator>http://orcid.org/0000-0002-6601-2165</dc:creator>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/envo/modules/entity_quality_location.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 45 Logical Axioms: 6]</rdfs:comment>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/envo/modules/entity_attribute_location.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 138 Logical Axioms: 23]</rdfs:comment>
         <dc:creator>https://orcid.org/0000-0002-6962-2807</dc:creator>

--- a/observation/ECSO8.owl
+++ b/observation/ECSO8.owl
@@ -14456,7 +14456,7 @@ http://en.wikipedia.org/wiki/Ecosystem_respiration</obo:IAO_0000119>
     <!-- http://purl.dataone.org/odo/ECSO_00001854 -->
 
     <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00001854">
-        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000512"/>
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00001800"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
         <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-12-04T21:04:31Z</dc:date>
         <rdfs:label xml:lang="en">glacier acidity</rdfs:label>
@@ -17842,7 +17842,11 @@ http://en.wikipedia.org/wiki/Ecosystem_respiration</obo:IAO_0000119>
         <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000668"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
         <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-04-29T23:09:22Z</dc:date>
+        <oboInOwl:hasExactSynonym>D14C of POC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Delta C 14 of POC</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">D14C of particulate organic carbon</rdfs:label>
+        <skos:altLabel>D14C of POC</skos:altLabel>
+        <skos:altLabel>Delta C 14 of POC</skos:altLabel>
     </owl:Class>
     
 
@@ -17853,7 +17857,13 @@ http://en.wikipedia.org/wiki/Ecosystem_respiration</obo:IAO_0000119>
         <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000669"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
         <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-04-29T23:09:59Z</dc:date>
+        <oboInOwl:hasExactSynonym>d13C of POC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>delta C 13 of POC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>delta C 13 of particulate organic carbon</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">d13C of particulate organic carbon</rdfs:label>
+        <skos:altLabel>d13C of POC</skos:altLabel>
+        <skos:altLabel>delta C 13 of POC</skos:altLabel>
+        <skos:altLabel>delta C 13 of particulate organic carbon</skos:altLabel>
     </owl:Class>
     
 
@@ -25872,7 +25882,9 @@ http://en.wikipedia.org/wiki/Ecosystem_respiration</obo:IAO_0000119>
         <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000669"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
         <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-05-07T20:42:13Z</dc:date>
+        <oboInOwl:hasExactSynonym>delta C 13 in sediment</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">d13C in sediment</rdfs:label>
+        <skos:altLabel>delta C 13 in sediment</skos:altLabel>
     </owl:Class>
     
 
@@ -25928,7 +25940,9 @@ http://en.wikipedia.org/wiki/Ecosystem_respiration</obo:IAO_0000119>
         <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000669"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
         <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-05-07T21:16:38Z</dc:date>
+        <oboInOwl:hasExactSynonym>delta C 13 in freshwater</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">d13C in freshwater</rdfs:label>
+        <skos:altLabel>delta C 13 in freshwater</skos:altLabel>
     </owl:Class>
     
 
@@ -27402,7 +27416,7 @@ http://en.wikipedia.org/wiki/Ecosystem_respiration</obo:IAO_0000119>
     <!-- http://purl.dataone.org/odo/ECSO_00003014 -->
 
     <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003014">
-        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000512"/>
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000520"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
         <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-05-31T18:41:11Z</dc:date>
         <rdfs:label xml:lang="en">concentration of total lipids extracted</rdfs:label>
@@ -28592,8 +28606,12 @@ http://en.wikipedia.org/wiki/Soil_organic_matter, 2017-07-08</obo:IAO_0000119>
         <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
         <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-23T23:22:16Z</dc:date>
         <oboInOwl:hasExactSynonym>d13C CO2</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">d13C carbon dioxide</rdfs:label>
+        <oboInOwl:hasExactSynonym>delta C 13 of CO2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>delta C 13 of carbon dioxide</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">d13C of carbon dioxide</rdfs:label>
         <skos:altLabel>d13C CO2</skos:altLabel>
+        <skos:altLabel>delta C 13 of CO2</skos:altLabel>
+        <skos:altLabel>delta C 13 of carbon dioxide</skos:altLabel>
     </owl:Class>
     
 
@@ -28607,6 +28625,72 @@ http://en.wikipedia.org/wiki/Soil_organic_matter, 2017-07-08</obo:IAO_0000119>
         <oboInOwl:hasExactSynonym>uncertainty of d13C CO2</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">uncertainty of d13C carbon dioxide</rdfs:label>
         <skos:altLabel>uncertainty of d13C CO2</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00003117 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003117">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000668"/>
+        <obo:IAO_0000115>A D14C measurement of carbon dioxide in the atmosphere.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-24T06:26:15Z</dc:date>
+        <oboInOwl:hasExactSynonym>D14C of CO2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Delta C 14 of CO2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Delta C 14 of carbon dioxide</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">D14C of carbon dioxide</rdfs:label>
+        <skos:altLabel>D14C of CO2</skos:altLabel>
+        <skos:altLabel>Delta C 14 of CO2</skos:altLabel>
+        <skos:altLabel>Delta C 14 of carbon dioxide</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00003118 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003118">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000666"/>
+        <obo:IAO_0000115>A measurement of the amount of carbon dioxide released by soil respiration.</obo:IAO_0000115>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-24T06:55:17Z</dc:date>
+        <rdfs:label xml:lang="en">amount of soil respiration</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.dataone.org/odo/ECSO_00003118"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A measurement of the amount of carbon dioxide released by soil respiration.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:resource="https://www.nrcs.usda.gov/Internet/FSE_DOCUMENTS/nrcs142p2_053267.pdf"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00003119 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003119">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000520"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-24T07:58:08Z</dc:date>
+        <oboInOwl:hasExactSynonym rdf:resource="PLFA concentration"/>
+        <rdfs:label xml:lang="en">phospholipid fatty acid concentration</rdfs:label>
+        <skos:altLabel rdf:resource="PLFA concentration"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.dataone.org/odo/ECSO_00003120 -->
+
+    <owl:Class rdf:about="http://purl.dataone.org/odo/ECSO_00003120">
+        <rdfs:subClassOf rdf:resource="http://purl.dataone.org/odo/ECSO_00000668"/>
+        <dc:creator rdf:resource="http://orcid.org/0000-0003-1264-1166"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-24T18:27:06Z</dc:date>
+        <oboInOwl:hasExactSynonym>D14C of PLFA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Delta C 14 of PLFA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Delta C 14 of phospholipid fatty acid</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">D14C of phospholipid fatty acid</rdfs:label>
+        <skos:altLabel>D14C of PLFA</skos:altLabel>
+        <skos:altLabel>Delta C 14 of PLFA</skos:altLabel>
+        <skos:altLabel>Delta C 14 of phospholipid fatty acid</skos:altLabel>
     </owl:Class>
     
 


### PR DESCRIPTION
This PR has new terms that were added to annotate the more recent ADC carbon measurements (~after 6/2019).  It's related to: https://github.nceas.ucsb.edu/KNB/arctic-data/issues/320#issuecomment-25265

After this PR gets merged, the version of ECSO8 in Github (in the ECSO8-add_non_carbon_measurements branch) will be ahead of the ECSO version used to index the semantic annotations in ADC production -- (i.e. the ADC production ECSO file will need to be manually synced with the version in Github).  