### PR TITLE
Add initial SHACL GHA

### DIFF
--- a/.github/workflows/shacl.yml
+++ b/.github/workflows/shacl.yml
@@ -1,0 +1,18 @@
+name: SHACL
+
+on:
+  push:
+    branches:
+      - main
+      - feature-102-shacl
+
+jobs:
+  SHACL:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - run: python -m pip install pyshacl
+      - run: pyshacl -s ./MOSAiC/dev/shapes.shacl -df xml -sf turtle ./MOSAiC/MOSAiC.owl

--- a/MOSAiC/dev/README.md
+++ b/MOSAiC/dev/README.md
@@ -1,0 +1,7 @@
+# MOSAiC Development Tools
+
+## SHACL Validation
+
+```
+pyshacl -s ./MOSAiC/dev/shapes.shacl -df xml -sf turtle ./MOSAiC/MOSAiC.owl
+```

--- a/MOSAiC/dev/shapes.shacl
+++ b/MOSAiC/dev/shapes.shacl
@@ -1,0 +1,21 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix mosaic: <https://purl.dataone.org/odo/MOSAIC_> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+
+mosaic:CampaignShape
+    a sh:NodeShape ;
+    sh:targetClass mosaic:00000001;
+    # Every Campaign has at least one sosa:hosts triple
+    sh:property [
+        sh:path sosa:hosts ;
+        sh:minCount 1 ;
+    ] ;
+    # Every Campaign has at least one mosaic:hasBasis triple
+    sh:property [
+        sh:path mosaic:00000034 ;
+        sh:minCount 1 ;
+    ] .


### PR DESCRIPTION
Ref #102

Adds a GHA to run a barebones SHACL shape constraint on the MOSAiC ontology. This can be extended to cover more rules for MOSAiC and also for other ontologies. Once merged, I'll probably mix it in with the current CI GHA so it all runs together in a single pipeline.