### PR TITLE
Add run size to salmon ontology

### DIFF
--- a/salmon/SALMON.ttl
+++ b/salmon/SALMON.ttl
@@ -6979,7 +6979,7 @@ That is, in some cases \"Total Age\" might be reported FW+SW+1, while in other c
                                               rdfs:subClassOf <http://purl.dataone.org/odo/SALMON_00000504> ;
                                               dc:creator <http://orcid.org/0009-0007-8384-5074> ;
                                               dc:date "2024-08-02T22:28:19Z"^^xsd:dateTime ;
-                                              rdfs:comment "Number of salmon swimming upstream to spawn. This includes both harvest and escapement counts." ;
+                                              obo:IAO_0000115 "Number of salmon swimming upstream to spawn. This includes both harvest and escapement counts." ;
                                               rdfs:label "run size"@en ;
                                               skos:relatedMatch <http://purl.dataone.org/odo/SALMON_00000491>;
                                               skos:relatedMatch <http://purl.dataone.org/odo/SALMON_00000479>.

--- a/salmon/SALMON.ttl
+++ b/salmon/SALMON.ttl
@@ -6974,6 +6974,17 @@ That is, in some cases \"Total Age\" might be reported FW+SW+1, while in other c
                                               skos:exactMatch <http://purl.dataone.org/odo/SALMON_00000461> .
 
 
+###  http://purl.dataone.org/odo/SALMON_00000573
+<http://purl.dataone.org/odo/SALMON_00000573> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://purl.dataone.org/odo/SALMON_00000504> ;
+                                              dc:creator <http://orcid.org/0009-0007-8384-5074> ;
+                                              dc:date "2024-08-02T22:28:19Z"^^xsd:dateTime ;
+                                              rdfs:comment "Number of salmon swimming upstream to spawn. This includes both harvest and escapement counts." ;
+                                              rdfs:label "run size"@en ;
+                                              skos:relatedMatch <http://purl.dataone.org/odo/SALMON_00000491>;
+                                              skos:relatedMatch <http://purl.dataone.org/odo/SALMON_00000479>.
+
+
 ###  http://purl.obolibrary.org/obo/ENVO_00000032
 <http://purl.obolibrary.org/obo/ENVO_00000032> rdf:type owl:Class .
 


### PR DESCRIPTION
I added "run size" term to the SALMON ontology

- label: run size
- rdfs:subClassOf <http://purl.dataone.org/odo/SALMON_00000504>
- definition: Number of salmon swimming upstream to spawn. This includes both harvest and escapement counts.
- skos:relatedMatch <http://purl.dataone.org/odo/SALMON_00000491>
- skos:relatedMatch <http://purl.dataone.org/odo/SALMON_00000479>

One thing I noticed is that a lot of the terms in SALMON.ttl had their definition under rdfs:comment instead of obo:IAO_0000115 like in the ARCRC.ttl. I'm not sure which to use. I also saw skos:definition being used in SALMON.ttl